### PR TITLE
No virtual keyboard with hardware keyboard

### DIFF
--- a/leankeykeyboard/src/main/java/com/google/leanback/ime/LeanbackImeService.java
+++ b/leankeykeyboard/src/main/java/com/google/leanback/ime/LeanbackImeService.java
@@ -246,13 +246,14 @@ public class LeanbackImeService extends InputMethodService {
     }
 
     /**
+     * super.onEvaluateInputViewShown() checks having hardware keyboard
      * At this point, decision whether to show kbd taking place
      * @return whether to show kbd
      */
     @SuppressLint("MissingSuperCall")
     @Override
     public boolean onEvaluateInputViewShown() {
-        return mKeyboardController.showInputView();
+        return mKeyboardController.showInputView() && super.onEvaluateInputViewShown();
     }
 
     @Override


### PR DESCRIPTION
Написал на вики целое исследование, но совершенно случайно обнаружил, что вся нужная логика есть в методе onEvaluateInputViewShown(). Привожу его целиком:
```
    /**
     * Override this to control when the soft input area should be shown to the user.  The default
     * implementation returns {@code false} when there is no hard keyboard or the keyboard is hidden
     * unless the user shows an intention to use software keyboard.  If you change what this
     * returns, you will need to call {@link #updateInputViewShown()} yourself whenever the returned
     * value may have changed to have it re-evaluated and applied.
     *
     * <p>When you override this method, it is recommended to call
     * {@code super.onEvaluateInputViewShown()} and return {@code true} when {@code true} is
     * returned.</p>
     */
    @CallSuper
    public boolean onEvaluateInputViewShown() {
        if (mSettingsObserver == null) {
            Log.w(TAG, "onEvaluateInputViewShown: mSettingsObserver must not be null here.");
            return false;
        }
        if (mSettingsObserver.shouldShowImeWithHardKeyboard()) {
            return true;
        }
        Configuration config = getResources().getConfiguration();
        return config.keyboard == Configuration.KEYBOARD_NOKEYS
                || config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES;
    }
```

Что характерно, [оригинальная клавиатура](https://cs.android.com/android/platform/superproject/+/master:packages/inputmethods/LeanbackIME/src/com/android/inputmethod/leanback/service/LeanbackImeService.java;bpv=1;bpt=1;l=179) специально показывает себя вместе с железной